### PR TITLE
fix(#45): tar_make() syntax error + silent error swallowing

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -133,7 +133,7 @@ jobs:
           nix-shell default.nix -A shell --run "Rscript -e '
             targets::tar_config_set(store = \"_targets\")
             targets::tar_make()
-          '" || echo "Targets pipeline completed with warnings"
+          '"
 
       # ── Verify Email Freshness ───────────────────────────────
       # Fail-fast: if email_summary_data has stale ingestion_stats, abort

--- a/R/tar_plans/plan_data_validation.R
+++ b/R/tar_plans/plan_data_validation.R
@@ -402,12 +402,12 @@ plan_data_validation <- list(
       )
 
       cli::cli_h2("Data Validation Report")
-      cli::cli_alert_info(
-        "Stations: {nrow(report$temporal_coverage)} | " %
-        "Gaps: {nrow(report$temporal_gaps)} | " %
-        "Duplicates: {report$duplicate_check$duplicates} | " %
+      cli::cli_alert_info(paste0(
+        "Stations: {nrow(report$temporal_coverage)} | ",
+        "Gaps: {nrow(report$temporal_gaps)} | ",
+        "Duplicates: {report$duplicate_check$duplicates} | ",
         "Freshness: {report$freshness$hours_old}h"
-      )
+      ))
 
       report
     },


### PR DESCRIPTION
## Summary

- Fix syntax error in `plan_data_validation.R:406` — broken `%` string concatenation crashes `tar_make()` on every CI run
- Remove `|| echo "Targets pipeline completed with warnings"` — `tar_make()` failures must fail the workflow, not be silently swallowed

This is why the dashboard still shows data from 2026-02-05 despite daily successful CI runs. ERDDAP data is fresh (all 5 stations through today) but `tar_make()` crashes immediately, vignettes render from cached stale targets, and stale HTML gets deployed.

## Test plan

- [ ] `tar_validate()` passes (no syntax errors in plan files)
- [ ] `devtools::check()` — 0 errors
- [ ] Manually trigger weekly-update after merge → dashboard shows fresh data

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)