### PR TITLE
feat(#53): API Tier 1 - metadata + high-value endpoints

### DIFF
--- a/inst/extdata/ctx/irishbuoys.ctx.yaml
+++ b/inst/extdata/ctx/irishbuoys.ctx.yaml
@@ -1044,35 +1044,3 @@ arguments:
   ci_comparison_per_station: Tibble with columns return_period, return_level, lower, upper, station, variable, method.
   return_levels_per_station: Tibble with columns return_period, return_level, lower, upper, station, variable, variable_label.
 returns: A list with _meta and data fields.
----
-kind: function
-name: generate_api_decomposition
-exported: true
-signature: generate_api_decomposition(decomp_per_station)
-arguments:
-  decomp_per_station: Named list of per-station decomposition results.
-returns: A list with _meta and data fields.
----
-kind: function
-name: generate_api_spatial
-exported: true
-signature: generate_api_spatial(pair_wave, pair_wind, pair_hmax)
-arguments:
-  pair_hmax: Data frame from analyze_station_pairs() for Hmax.
-  pair_wave: Data frame from analyze_station_pairs() for wave height.
-  pair_wind: Data frame from analyze_station_pairs() for wind speed.
-returns: A list with _meta and data fields.
----
-kind: function
-name: generate_api_gust_factors
-exported: true
-signature: generate_api_gust_factors(gust_analysis)
-arguments:
-  gust_analysis: List from analyze_gust_factor() containing summary, extreme_gusts, by_station, rogue_gust_threshold, n_rogue_gusts, pct_rogue_gusts.
-returns: A list with _meta and data fields.
----
-kind: function
-name: generate_api_methods
-exported: true
-signature: generate_api_methods()
-returns: A list with _meta and data fields.


### PR DESCRIPTION
## Summary
- Add 4 new static API endpoints: `sources.json`, `status.json`, `trends.json`, `extremes.json`
- Retrofit `_meta` block (generated timestamp, package_version, endpoint, description) to all 12 endpoints
- Add `.api_meta()` / `.api_wrap()` internal helpers for consistent metadata
- Fix pre-existing CI bug: `hmax_hs_ratio` -> `rogue_ratio` in `api_vignette_rogue_waves_dt`

### New endpoints
| Endpoint | Source | Description |
|----------|--------|-------------|
| `sources.json` | Pure constants | ERDDAP provenance, license, citation |
| `status.json` | `dashboard_stats` | Per-station record counts, date ranges |
| `trends.json` | `mk_per_station` + annual trends | Mann-Kendall per station/variable |
| `extremes.json` | `return_levels_per_station` + `ci_comparison_per_station` | GPD fits + CI methods combined |

### Files changed
- `R/api_static.R` — 4 new exported functions + 2 internal helpers
- `R/tar_plans/plan_api.R` — 5 new targets, _meta retrofit, CI bugfix
- `tests/testthat/test-api-static.R` — 6 new test blocks (14 total)
- `vignettes/api-usage.qmd` — 4 new endpoint docs, updated accessors
- `NAMESPACE` + `man/` — auto-generated

Part 1 of 3 for #53. Tests: 842 pass, 0 fail.

## Test plan
- [ ] `devtools::test(filter = "api-static")` — all 14 tests pass
- [ ] `devtools::test()` — full suite 842 pass, 0 fail
- [ ] `pkgload::load_all()` — package loads cleanly
- [ ] `devtools::document()` — NAMESPACE updated correctly
- [ ] CI Data Update workflow no longer fails on `hmax_hs_ratio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)