### PR TITLE
fix: use correct HF repo dsfefvx/irish-buoy-network

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -311,7 +311,7 @@ jobs:
           git push || true
 
       # ── Push Parquet to HuggingFace ─────────────────────────
-      # Public dataset at hf://datasets/JohnGavin/irish-buoy-network
+      # Public dataset at hf://datasets/dsfefvx/irish-buoy-network
       # Uses git clone + git-lfs push (NOT REST API)
 
       - name: Push Parquet to HuggingFace
@@ -331,7 +331,7 @@ jobs:
 
           TMPDIR=$(mktemp -d)
           git clone --depth 1 \
-            "https://hf-user:${HF_TOKEN}@huggingface.co/datasets/JohnGavin/irish-buoy-network" \
+            "https://hf-user:${HF_TOKEN}@huggingface.co/datasets/dsfefvx/irish-buoy-network" \
             "$TMPDIR/repo" || {
             echo "::warning::HF clone failed — skipping push"
             rm -rf "$TMPDIR"

--- a/R/huggingface.R
+++ b/R/huggingface.R
@@ -11,7 +11,7 @@
 #' ib_hf_url()
 #' ib_hf_url("stations.json")
 ib_hf_url <- function(filename = "buoy_data.parquet") {
-  repo <- Sys.getenv("IB_HF_REPO", unset = "JohnGavin/irish-buoy-network")
+  repo <- Sys.getenv("IB_HF_REPO", unset = "dsfefvx/irish-buoy-network")
   sprintf("hf://datasets/%s/%s", repo, filename)
 }
 
@@ -26,7 +26,7 @@ ib_hf_url <- function(filename = "buoy_data.parquet") {
 #' @examples
 #' ib_hf_online()
 ib_hf_online <- function() {
-  repo <- Sys.getenv("IB_HF_REPO", unset = "JohnGavin/irish-buoy-network")
+  repo <- Sys.getenv("IB_HF_REPO", unset = "dsfefvx/irish-buoy-network")
   url <- sprintf("https://huggingface.co/api/datasets/%s", repo)
   tryCatch(
     {

--- a/tests/testthat/_snaps/huggingface.md
+++ b/tests/testthat/_snaps/huggingface.md
@@ -3,14 +3,14 @@
     Code
       ib_hf_url()
     Output
-      [1] "hf://datasets/JohnGavin/irish-buoy-network/buoy_data.parquet"
+      [1] "hf://datasets/dsfefvx/irish-buoy-network/buoy_data.parquet"
 
 ---
 
     Code
       ib_hf_url("stations.json")
     Output
-      [1] "hf://datasets/JohnGavin/irish-buoy-network/stations.json"
+      [1] "hf://datasets/dsfefvx/irish-buoy-network/stations.json"
 
 # local Parquet schema snapshot
 

--- a/tests/testthat/test-huggingface.R
+++ b/tests/testthat/test-huggingface.R
@@ -4,7 +4,7 @@ test_that("ib_hf_url returns correct hf:// URL", {
   url <- ib_hf_url()
   expect_match(url, "^hf://datasets/")
   expect_match(url, "buoy_data\\.parquet$")
-  expect_equal(url, "hf://datasets/JohnGavin/irish-buoy-network/buoy_data.parquet")
+  expect_equal(url, "hf://datasets/dsfefvx/irish-buoy-network/buoy_data.parquet")
 })
 
 test_that("ib_hf_url accepts custom filename", {


### PR DESCRIPTION
## Summary

- HF token belongs to user `dsfefvx`, not `JohnGavin`
- Updated default repo from `JohnGavin/irish-buoy-network` to `dsfefvx/irish-buoy-network` in all files
- Initial Parquet (300K+ rows, 7MB) pushed to HF and verified: `ib_hf_online()` returns TRUE
- Dataset live at: https://huggingface.co/datasets/dsfefvx/irish-buoy-network

## Test plan

- [x] `ib_hf_online()` returns TRUE
- [x] 12/12 HF tests pass
- [ ] Add `HF_TOKEN` as GitHub Actions secret for CI auto-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)