### PR TITLE
feat: add perspectiveR to Nix via git_pkgs

### DIFF
--- a/default.R
+++ b/default.R
@@ -52,8 +52,6 @@ viz_pkgs <- c(
   "scales",         # Scale functions
   "DT",             # Interactive tables
   "dygraphs",       # Time series plots
-  # perspectiveR: not in nixpkgs 2026-01-19 snapshot; install separately
-  # install.packages("perspectiveR") outside nix-shell
   "shiny",          # Shiny web apps
   "shinylive"       # Shinylive deployment
 )
@@ -91,7 +89,14 @@ rix::rix(
   date = "2026-01-19",
   r_pkgs = all_r_pkgs,
   system_pkgs = system_pkgs,
-  git_pkgs = NULL,
+  # perspectiveR: pure R+JS htmlwidgets (no compilation), not in nixpkgs 2026-01-19
+  git_pkgs = list(
+    list(
+      package_name = "perspectiveR",
+      repo_url = "https://github.com/EydlinIlya/perspectiveR",
+      commit = "c0cc8c7482ee511fd888885d919aca3a5af9e03c"
+    )
+  ),
   ide = "none",
   project_path = ".",
   overwrite = TRUE,

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,9 @@
 # >rix::rix(date = "2026-01-19",
 #  > r_pkgs = all_r_pkgs,
 #  > system_pkgs = system_pkgs,
-#  > git_pkgs = NULL,
+#  > git_pkgs = list(list(package_name = "perspectiveR",
+#  > repo_url = "https://github.com/EydlinIlya/perspectiveR",
+#  > commit = "c0cc8c7482ee511fd888885d919aca3a5af9e03c")),
 #  > ide = "none",
 #  > project_path = ".",
 #  > overwrite = TRUE,
@@ -71,6 +73,21 @@ let
       xts
       zoo;
   };
+ 
+    perspectiveR = (pkgs.rPackages.buildRPackage {
+      name = "perspectiveR";
+      src = pkgs.fetchgit {
+        url = "https://github.com/EydlinIlya/perspectiveR";
+        rev = "c0cc8c7482ee511fd888885d919aca3a5af9e03c";
+        sha256 = "sha256-DGdIdQJtLwdtlW4hGn564Xq0kj9NAgA+z2pviN5Wq1I=";
+      };
+      propagatedBuildInputs = builtins.attrValues {
+        inherit (pkgs.rPackages) 
+          htmlwidgets
+          htmltools
+          jsonlite;
+      };
+    });
       
   system_packages = builtins.attrValues {
     inherit (pkgs) 
@@ -92,7 +109,7 @@ let
     LC_PAPER = "en_US.UTF-8";
     LC_MEASUREMENT = "en_US.UTF-8";
     
-    buildInputs = [ rpkgs system_packages ];
+    buildInputs = [ perspectiveR rpkgs system_packages ];
     
   }; 
 in


### PR DESCRIPTION
## Summary

perspectiveR v0.3.1 is not in nixpkgs 2026-01-19 snapshot. Added via `rix::rix(git_pkgs = ...)` pointing to GitHub commit `c0cc8c7`.

- Pure R+JS htmlwidgets package (no C/C++ compilation needed)
- Builds in ~10s, loads successfully: `library(perspectiveR)` OK
- All 1418 tests pass (0 new failures)
- Unblocks #72 Phase 2 (replace 34MB dashboard)

## How it works

```r
# In default.R
git_pkgs = list(
  list(
    package_name = "perspectiveR",
    repo_url = "https://github.com/EydlinIlya/perspectiveR",
    commit = "c0cc8c7482ee511fd888885d919aca3a5af9e03c"
  )
)
```

rix generates a `buildRPackage` derivation that fetches from GitHub and installs from source.

## Test plan

- [x] `library(perspectiveR)` loads in nix-shell
- [x] Full test suite: 1418 pass, 2 pre-existing fails
- [ ] Push to johngavin cachix (CI seed-cachix.yml will handle)
- [ ] Render `dashboard_perspective.qmd` with perspectiveR available

🤖 Generated with [Claude Code](https://claude.com/claude-code)