### PR TITLE
fix(ci): grant issues:write to Website Freshness Monitor (#73)

### DIFF
--- a/.github/workflows/website-freshness-check.yml
+++ b/.github/workflows/website-freshness-check.yml
@@ -14,6 +14,14 @@ on:
     - cron: '0 6,18 * * *'  # 06:00 and 18:00 UTC
   workflow_dispatch:
 
+# The "create issue" steps need issues:write; the default GITHUB_TOKEN is
+# read-only when the repo/org default is restricted, which made this workflow
+# fail ("Resource not accessible by integration (createIssue)") the moment the
+# dashboard data crossed the 48h staleness threshold (#73).
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   website-freshness:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
The Website Freshness Monitor (`website-freshness-check.yml`) failed once dashboard data crossed the 48h threshold, with:
`GraphQL: Resource not accessible by integration (createIssue)`.

The check step worked and correctly detected stale data (58h), but the **create-issue** step couldn't run because the workflow's `GITHUB_TOKEN` lacked `issues: write`. It passed previously only because fresh data skipped the create-issue steps.

## Fix
Add an explicit top-level `permissions:` block (`contents: read`, `issues: write`).

## Note
Surfaced while investigating why irishbuoys was "updating" without manual work (answer: daily `data-update.yml` automation → r-universe rebuilds). Separately filed #89 for the 3.1 GB `.git` bloat (verified cause: ~1 GB rendered docs + data committed to main for the Pages deploy; `_targets/` historical residue).