### PR TITLE
ci(#89): deploy Pages from build artifact — stop committing rendered HTML to main

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -298,6 +298,15 @@ jobs:
             fi
           done
 
+      # ── Upload built site for Pages deploy (#89: don't commit HTML to main) ──
+
+      - name: Upload built site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: docs
+          retention-days: 1
+
       # ── Commit Rendered Outputs to main ─────────────────────
 
       - name: Commit rendered outputs to main
@@ -305,8 +314,10 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add inst/extdata/*.rds || true
-          git add docs/api/ || true
-          git add docs/articles/ docs/vignettes/ || true
+          # #89: do NOT commit rendered HTML to main (it bloated .git to 3.1 GB).
+          # Only the Parquet (needed by next run's DuckDB bootstrap) is committed;
+          # the full rendered site deploys from the build artifact (deploy-pages job).
+          git add docs/vignettes/data/buoy_data.parquet || true
           git diff --staged --quiet || git commit -m "Data update (${{ github.event_name }}): $(date +'%Y-%m-%dT%H:%M')Z"
           git push || true
 
@@ -418,29 +429,27 @@ jobs:
       group: "pages"
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - name: Download built site (from update-data; #89 — not committed to main)
+        uses: actions/download-artifact@v4
         with:
-          ref: main  # Checkout after update-data has pushed
+          name: site
+          path: docs
 
       - name: Verify docs exist
         run: |
           if [ ! -f "docs/index.html" ]; then
-            echo "::warning::No docs/index.html found — skipping deploy"
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::error::No docs/index.html in built site artifact"
+            exit 1
           fi
-        id: check
 
       - name: Setup Pages
-        if: steps.check.outputs.skip != 'true'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        if: steps.check.outputs.skip != 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
-        if: steps.check.outputs.skip != 'true'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -36,7 +36,7 @@ jobs:
   # No gate job needed — cron runs are routine, other triggers are intentional.
   update-data:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120  # runs routinely take 79-89 min; 90 was too tight (#89)
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,10 +1,9 @@
 name: Deploy Dashboard to GitHub Pages
 
+# #89: docs/ is no longer committed to main — the data-update workflow deploys
+# Pages from its build artifact. Kept for manual redeploys only; the push
+# trigger is disabled so this never deploys an HTML-less main.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,15 @@ docs/_extensions/
 # Except allow dashboard data files
 !docs/
 !docs/**
+
+# #89: rendered HTML must NOT be committed to main — the full site deploys from
+# the build artifact (data-update.yml deploy-pages job). Only dashboard DATA
+# (parquet/json, re-included above) stays committed for the next-run bootstrap.
+docs/articles/
+docs/api/
+docs/vignettes/*.html
+docs/vignettes/*_files/
+
 .DS_Store
 tests/testthat/_problems/
 tests/testthat/testthat-problems.rds


### PR DESCRIPTION
**DRAFT — must be tested via `workflow_dispatch` before merge.** Touches the live daily pipeline + Pages deploy.

## Why
Per the forensics in #89, ~1 GB of the 3.1 GB `.git` is **rendered dashboard HTML committed to `main` daily**. It was committed only so the deploy jobs could upload `docs/` to Pages from a `main` checkout.

## What changed (Phase 1 — stop the bleeding; HTML only, parquet kept)
- **`data-update.yml`**
  - `update-data`: uploads the built `docs/` as a `site` artifact.
  - `deploy-pages`: **downloads that artifact and deploys** (no `checkout ref: main`).
  - commit step: stages **only `docs/vignettes/data/buoy_data.parquet`** (next-run DuckDB bootstrap needs it) — no longer `git add docs/articles/ docs/vignettes/`.
- **`deploy-dashboard.yml`**: push trigger disabled (`workflow_dispatch` only) — it would otherwise deploy an HTML-less `main`.
- **`.gitignore`**: excludes rendered HTML under `docs/` (data files still allowed).

## Scope / non-goals
- **Stops FUTURE growth only.** The ~2.7 GB already in history (HTML + `_targets/` residue + old parquet) is removed by the **Phase 2 history rewrite** (#89), which needs a backup + explicit go-ahead.
- `inst/extdata/*.rds` is still committed (kept in scope to HTML-only); can be a follow-up.
- Existing already-tracked HTML files are left in place (Phase 2 removes them from history).

## Test checklist before merge (run `workflow_dispatch` on this branch)
- [ ] `Data Update` run succeeds end-to-end.
- [ ] `deploy-pages` job deploys; **published dashboard at johngavin.github.io/irishbuoys still loads** (charts + data).
- [ ] No `docs/` HTML appears in the commit pushed to `main` (only the parquet, if changed).
- [ ] Next run's **DuckDB bootstrap** still finds `buoy_data.parquet`.

Closes part of #89 (Phase 1). Prevention: JohnGavin/llm#651.