### PR TITLE
fix(telemetry): add model_clean to empty-branch tibble — unblocks daily pipeline

### DIFF
--- a/R/tar_plans/plan_telemetry.R
+++ b/R/tar_plans/plan_telemetry.R
@@ -930,7 +930,8 @@ plan_telemetry <- list(
           total_cost = numeric(),
           total_tokens = integer(),
           n_requests = integer(),
-          pct_cost = numeric()
+          pct_cost = numeric(),
+          model_clean = character()
         ))
       }
 


### PR DESCRIPTION
## Root Cause

`tar_make()` failed at `table_telemetry_llm_by_model` with:

```
✖ Column 'model_clean' doesn't exist
```

The latent bug was in `R/tar_plans/plan_telemetry.R` at the `telemetry_llm_by_model` target (~line 927). When telemetry data is empty (the current state, because the telemetry ETL is stale — see JohnGavin/llmtelemetry#309), the early-return tibble was:

```r
tibble::tibble(
  model = character(),
  total_cost = numeric(),
  total_tokens = integer(),
  n_requests = integer(),
  pct_cost = numeric()
  # model_clean was MISSING here
)
```

The non-empty branch adds `model_clean` via `mutate(model_clean = gsub("claude-", "", model))`. The downstream `table_telemetry_llm_by_model` then calls `dplyr::select(-model) |> dplyr::rename(model = model_clean)` — which throws on the empty branch.

## Fix

Added `model_clean = character()` to the empty-branch return tibble so its schema matches the non-empty branch exactly. Minimal one-line change.

## Other Empty-Branch Mismatches Audited

Checked all other `return(tibble::tibble(...))` patterns in the file. No additional mismatches found:

- `plot_telemetry_llm_by_model` (line 1022): guards with `if (nrow(data) == 0) return(NULL)` — safe, `model_clean` never reaches the `aes()` call on an empty frame
- All other early-return tibbles (`telemetry_llm_sessions`, `telemetry_llm_daily`, `telemetry_llm_summary`, `telemetry_target_metrics`, `telemetry_commit_velocity`, `telemetry_test_stats`) are schema-consistent with their non-empty branches

## Both-Branches Test Output

```
=== Test A: Empty branch (FIXED) ===
Columns: model, total_cost, total_tokens, n_requests, pct_cost, model_clean
PASS: select(-model) |> rename(model = model_clean) worked on empty branch
Result rows: 0 cols: total_cost, total_tokens, n_requests, pct_cost, model

=== Test B: Non-empty branch ===
Columns: model, total_cost, total_tokens, n_requests, pct_cost, model_clean
PASS: select(-model) |> rename(model = model_clean) worked on non-empty branch
Result:
# A tibble: 1 × 5
  total_cost total_tokens n_requests pct_cost model
       <dbl>        <int>      <int>    <dbl> <chr>
1       1.23        50000         10      100 sonnet-4-5
```

## Relation to llmtelemetry#309

The telemetry ETL is currently stale (JohnGavin/llmtelemetry#309), which means `telemetry_llm_sessions` returns 0 rows, causing `telemetry_llm_daily` to return 0 rows, which triggers this empty branch every run. This PR makes the pipeline robust to the empty-data state so `tar_make()` completes cleanly regardless of whether telemetry data is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)