### PR TITLE
fix(ci): generate docs/index.html landing page so deploy-pages succeeds

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -298,6 +298,78 @@ jobs:
             fi
           done
 
+      - name: Generate landing page (docs/index.html)
+        run: |
+          mkdir -p docs
+          cat > docs/index.html <<'LANDING_EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>irishbuoys — Irish Weather Buoy Network</title>
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                     max-width: 800px; margin: 2rem auto; padding: 0 1rem;
+                     color: #333; background: #fafafa; }
+              h1   { color: #1a5276; border-bottom: 2px solid #1a5276; padding-bottom: 0.4rem; }
+              p.lead { font-size: 1.1rem; color: #555; margin-bottom: 1.5rem; }
+              ul   { list-style: none; padding: 0; }
+              li   { margin: 0.8rem 0; }
+              a    { color: #1a5276; font-weight: 600; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+              .desc { color: #666; font-size: 0.9rem; }
+              footer { margin-top: 3rem; font-size: 0.8rem; color: #aaa; }
+            </style>
+          </head>
+          <body>
+            <h1>irishbuoys — Irish Weather Buoy Network</h1>
+            <p class="lead">
+              Real-time and historical data from Ireland's network of offshore weather buoys,
+              updated daily from ERDDAP.
+            </p>
+            <ul>
+          LANDING_EOF
+
+          # Append links only for articles that actually exist (degrade gracefully)
+          add_link() {
+            local file="$1" href="$2" title="$3" desc="$4"
+            if [ -f "docs/articles/${file}" ]; then
+              cat >> docs/index.html <<LINK_EOF
+              <li><a href="${href}">${title}</a><br><span class="desc">${desc}</span></li>
+          LINK_EOF
+            else
+              echo "::warning::docs/articles/${file} not found — omitting from landing page"
+            fi
+          }
+
+          add_link "dashboard_static.html" "articles/dashboard_static.html" \
+            "Irish Buoys Explorer" \
+            "Interactive dashboard: current conditions, wave heights, sea temperature, and wind across all buoys."
+
+          add_link "wave_analysis.html" "articles/wave_analysis.html" \
+            "Irish Buoys Analysis" \
+            "Exploratory wave and meteorological analysis across the buoy network."
+
+          add_link "telemetry.html" "articles/telemetry.html" \
+            "Telemetry" \
+            "Pipeline telemetry: data-fetch metrics, ingestion statistics, and pipeline health."
+
+          add_link "api-usage.html" "articles/api-usage.html" \
+            "Static Data API" \
+            "How to access the pre-built Parquet dataset and static JSON API endpoints."
+
+          cat >> docs/index.html <<'FOOTER_EOF'
+            </ul>
+            <footer>
+              Built daily by <a href="https://github.com/JohnGavin/irishbuoys">irishbuoys</a>
+              &mdash; data from the Irish National Buoy Network via ERDDAP.
+            </footer>
+          </body>
+          </html>
+          FOOTER_EOF
+          echo "docs/index.html generated"
+
       # ── Upload built site for Pages deploy (#89: don't commit HTML to main) ──
 
       - name: Upload built site artifact


### PR DESCRIPTION
## Root cause

Issue #89 (git history rewrite to purge HTML from .git) removed the committed
pkgdown `index.html` artifact. The `deploy-pages` job checks for `docs/index.html`
and fails with `No docs/index.html in built site artifact` when it is absent.

The daily `update-data` build renders 4 vignettes and copies them to
`docs/articles/`, but never regenerated the root landing page — so the site root
returned a 404 and deploy-pages exited 1 on every run since #89.

## Fix

Add a **"Generate landing page (docs/index.html)"** step in `data-update.yml`,
placed **after** "Copy rendered vignettes to pkgdown articles directory" and
**before** "Upload built site artifact" (confirmed by `grep -n` at lines 284,
301, 375).

The step writes `docs/index.html` via a heredoc: a small, dependency-free HTML
page that:

- Has a project header (irishbuoys — Irish Weather Buoy Network) + one-sentence
  description.
- Links to each of the 4 built articles with **per-file existence guards** — if
  a vignette render failed, the link is omitted with a `::warning::` annotation
  instead of linking to a 404.
- Uses clean inline CSS; no external assets, no webR/shinylive.

Articles linked (all relative hrefs):
| File | Title |
|------|-------|
| `articles/dashboard_static.html` | Irish Buoys Explorer |
| `articles/wave_analysis.html`    | Irish Buoys Analysis |
| `articles/telemetry.html`        | Telemetry |
| `articles/api-usage.html`        | Static Data API |

The `deploy-pages` "Verify docs exist" step is left as-is; `docs/index.html`
will now be present in the artifact.

## What this replaces

The previous `index.html` was a committed `pkgdown::build_site()` artifact.
This PR replaces it with a lightweight self-maintained landing page that the CI
pipeline regenerates on every run. `pkgdown::build_site()` remains available as
a separate manual build if the full pkgdown site is ever wanted again.

## Verification

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open(...))"` — **OK**
- Scratch test: `mkdir -p docs/articles && touch dashboard_static.html wave_analysis.html telemetry.html` (api-usage absent) → generated `docs/index.html` contains 3 links, emits one `WARNING:` for missing api-usage.html, degrades gracefully.
- Step order: lines 284 (copy), 301 (generate landing), 375 (upload artifact).

Closes the deploy-pages failure introduced by #89.

References #89.