### PR TITLE
ci: replace targets-runs git-branch cache with actions/cache

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -1,15 +1,14 @@
 name: Data Update (daily)
 
-# Incremental pipeline using targets-runs branch pattern
-# (inspired by https://github.com/b-rodrigues/nix_targets_pipeline)
+# Incremental pipeline using actions/cache for _targets/ store
 #
 # How it works:
 #   1. Checkout main (source code)
-#   2. Restore _targets/ from targets-runs branch (incremental state)
+#   2. Restore _targets/ from actions/cache (incremental state)
 #   3. Run data update + tar_make() (only rebuilds changed targets)
 #   4. Render vignettes (tar_load works — _targets/ is present)
 #   5. Commit rendered outputs (inst/extdata/*.rds, docs/) to main
-#   6. Save _targets/ state to targets-runs branch for next run
+#   6. actions/cache auto-saves _targets/ at job end (next run restores it)
 #
 # Schedule:
 #   - Runs daily at 06:00 UTC
@@ -44,8 +43,6 @@ jobs:
       # ── Checkout & Environment ──────────────────────────────
 
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Full history needed for targets-runs branch
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -67,42 +64,23 @@ jobs:
         run: nix-build default.nix -A shell --no-out-link
 
       # ── Restore Pipeline State ──────────────────────────────
+      # actions/cache restores _targets/ from the most-recent prior run
+      # (restore-keys: targets- matches any earlier cache key).
+      # On cache miss the store is absent; tar_make() does a full build.
+      # actions/cache auto-saves _targets/ at job end when a new key is used.
 
-      - name: Check if targets-runs branch exists
-        id: runs-exist
-        run: git ls-remote --exit-code --heads origin targets-runs
-        continue-on-error: true
-
-      - name: Checkout previous pipeline state
-        if: steps.runs-exist.outcome == 'success'
-        uses: actions/checkout@v6
+      - name: Cache targets store
+        uses: actions/cache@v4
         with:
-          ref: targets-runs
-          fetch-depth: 1
-          path: .targets-runs
-
-      - name: Restore _targets/ from previous run
-        if: steps.runs-exist.outcome == 'success'
-        run: |
-          if [ -f ".targets-runs/.targets-files" ]; then
-            nix-shell default.nix -A shell --run "Rscript -e '
-              files <- scan(\".targets-runs/.targets-files\", what = character())
-              restored <- 0L
-              for (dest in files) {
-                source <- file.path(\".targets-runs\", dest)
-                if (!file.exists(dirname(dest))) dir.create(dirname(dest), recursive = TRUE)
-                if (file.exists(source)) { file.rename(source, dest); restored <- restored + 1L }
-              }
-              cat(\"Restored\", restored, \"pipeline files from targets-runs\\n\")
-            '"
-          else
-            echo "No .targets-files manifest found — running pipeline from scratch"
-          fi
+          path: _targets
+          key: targets-${{ github.run_id }}
+          restore-keys: |
+            targets-
 
       # ── Data Update & Pipeline ──────────────────────────────
-      # Pre-pipeline fetch: DuckDB is ephemeral in CI (gitignored, excluded from
-      # targets-runs). Without this step, tar_make() may use cached stale
-      # email_summary_data from targets-runs, sending emails with weeks-old data.
+      # Pre-pipeline fetch: DuckDB is ephemeral in CI (gitignored, not cached).
+      # Without this step, tar_make() may use cached stale email_summary_data
+      # (from _targets/ cache), sending emails with weeks-old data.
       # This fetch ensures the DB has fresh data BEFORE the pipeline runs.
 
       - name: Bootstrap DuckDB from Parquet (skip full ERDDAP fetch)
@@ -435,34 +413,6 @@ jobs:
 
           rm -rf "$TMPDIR"
 
-      # ── Save Pipeline State to targets-runs ─────────────────
-
-      - name: Identify pipeline output files
-        run: git ls-files -mo --exclude='*.duckdb' --exclude='.targets-runs' > .targets-files
-
-      - name: Create targets-runs branch if needed
-        if: steps.runs-exist.outcome != 'success'
-        run: git checkout --orphan targets-runs
-
-      - name: Switch to targets-runs branch
-        if: steps.runs-exist.outcome == 'success'
-        run: |
-          rm -r .git
-          mv .targets-runs/.git .
-          rm -rf .targets-runs
-
-      - name: Commit pipeline state to targets-runs
-        run: |
-          git config --local user.name "GitHub Actions"
-          git config --local user.email "actions@github.com"
-          rm -rf .gitignore .github/workflows
-          git add --all -- ':!*.duckdb'
-          for file in $(cat .targets-files); do
-            git add --force "$file" 2>/dev/null || true
-          done
-          git commit -am "Pipeline state: $(date +'%Y-%m-%d')" || echo "No changes to pipeline state"
-          git push origin targets-runs || echo "Failed to push targets-runs"
-
       # ── Artifacts ───────────────────────────────────────────
 
       - name: Upload update log
@@ -476,7 +426,7 @@ jobs:
 
       - name: Prepare failure artifact
         if: failure()
-        run: rm -rf .git .github .targets-files .targets-runs
+        run: rm -rf .git .github
 
       - name: Post failure artifact
         if: failure()


### PR DESCRIPTION
## Root cause

`.github/workflows/data-update.yml` persisted the `_targets/` pipeline store between runs via a separate `targets-runs` git branch. After that branch was deleted (a repo-cleanup), the workflow fell into its orphan-branch recreation path: it built a giant fresh root commit (1147 files / 487k insertions) and the final `git push origin targets-runs` **failed silently**, hidden by `|| echo "Failed to push targets-runs"`. Result: `_targets/` was never restored, so every subsequent run did a full ~80-minute rebuild from scratch — burning CI credits on work that was already done. The branch approach was also a git-bloat vector (ties to #89).

## Fix

Replace the 7-step git-branch cache machinery with a single `actions/cache@v4` step:

```yaml
- name: Cache targets store
  uses: actions/cache@v4
  with:
    path: _targets
    key: targets-${{ github.run_id }}
    restore-keys: |
      targets-
```

`actions/cache` restores `_targets/` from the most-recent prior run via the `targets-` restore prefix, and auto-saves it at job end when a new key is used. On cache miss, `tar_make()` does a full build and populates the cache for the next run.

## Steps removed

1. "Check if targets-runs branch exists" (`runs-exist`)
2. "Checkout previous pipeline state"
3. "Restore _targets/ from previous run"
4. "Identify pipeline output files"
5. "Create targets-runs branch if needed"
6. "Switch to targets-runs branch"
7. "Commit pipeline state to targets-runs"

## Steps added

1. "Cache targets store" (`actions/cache@v4`)

## After merge

- The first run after merge will do a full build and populate the GitHub Actions cache.
- Every subsequent run restores the cache incrementally — only changed targets rebuild.
- The `targets-runs` branch (which no longer exists on remote anyway) can be ignored; it is no longer used by any workflow.

## Verification

YAML parses cleanly. `grep -niE "targets-runs|\.targets-files|runs-exist"` returns zero matches in the updated file. No other workflows in `.github/workflows/` reference `targets-runs`.