### PR TITLE
fix(validation): use agent x-list all_passed (pointblank 0.12 compat)

### DIFF
--- a/R/validation.R
+++ b/R/validation.R
@@ -155,12 +155,14 @@ validate_buoy_data <- function(data,
     return(data)
   }
 
-  # Get failure summary
-  report <- pointblank::get_agent_report(agent, display_table = FALSE)
-  n_failed <- sum(!report$all_passed, na.rm = TRUE)
+  # Get failure summary. Use get_agent_x_list() rather than
+  # get_agent_report(): the report tibble has no `all_passed` column in
+  # pointblank >= 0.12, whereas the x_list's validation_set data frame
+  # carries `all_passed` and `stop` per validation step.
+  x_list <- pointblank::get_agent_x_list(agent)
+  n_failed <- sum(!x_list$validation_set$all_passed, na.rm = TRUE)
 
   # Check if we hit the stop threshold
-  x_list <- pointblank::get_agent_x_list(agent)
   any_stop <- any(x_list$validation_set$stop, na.rm = TRUE)
 
   if (any_stop) {
@@ -299,13 +301,15 @@ create_validation_summary <- function(...) {
   # Use lapply + bind_rows instead of purrr::map_dfr to avoid purrr dependency
   results <- lapply(names(agents), function(name) {
     agent <- agents[[name]]
-    report <- pointblank::get_agent_report(agent, display_table = FALSE)
+    # get_agent_report()'s tibble has no `all_passed` column in
+    # pointblank >= 0.12; use get_agent_x_list()'s validation_set instead.
+    x_list <- pointblank::get_agent_x_list(agent)
 
     tibble::tibble(
       target = name,
       status = if (pointblank::all_passed(agent)) "PASSED" else "FAILED",
-      checks_passed = sum(report$all_passed, na.rm = TRUE),
-      checks_total = nrow(report)
+      checks_passed = sum(x_list$validation_set$all_passed, na.rm = TRUE),
+      checks_total = nrow(x_list$validation_set)
     )
   })
   dplyr::bind_rows(results)

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -50,3 +50,19 @@
       x `data` must be a data frame
       i You provided <character>
 
+# validate_buoy_data output structure is stable
+
+    Code
+      sort(names(result))
+    Output
+      [1] "qc_flag"     "station_id"  "time"        "wave_height" "wind_speed" 
+
+# validate_buoy_data output structure is stable with complete data
+
+    Code
+      sort(names(result))
+    Output
+      [1] "atmospheric_pressure" "gust"                 "hmax"                
+      [4] "qc_flag"              "station_id"           "time"                
+      [7] "wave_height"          "wind_speed"          
+

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -80,11 +80,37 @@ test_that("validate_buoy_data error messages are stable", {
 })
 
 test_that("validate_buoy_data output structure is stable", {
+  # Incomplete data (missing hmax/gust/atmospheric_pressure) drives the
+  # all_passed(agent) == FALSE branch, which uses
+  # get_agent_x_list(agent)$validation_set$all_passed/$stop — the code
+  # path fixed for pointblank >= 0.12 (get_agent_report() lost its
+  # `all_passed` column). Keep this case to cover that branch.
   data <- data.frame(
     station_id = rep("M2", 10),
     time = seq(as.POSIXct("2024-01-01"), by = "hour", length.out = 10),
     wave_height = runif(10, 0.5, 5),
     wind_speed = runif(10, 2, 25),
+    qc_flag = rep(1L, 10),
+    stringsAsFactors = FALSE
+  )
+  result <- validate_buoy_data(data, min_rows = 1)
+  expect_snapshot(sort(names(result)))
+})
+
+test_that("validate_buoy_data output structure is stable with complete data", {
+  skip_if_not_installed("pointblank")
+  # Complete data (all columns pointblank checks against) drives the
+  # all_passed(agent) == TRUE early-return branch (validation.R L151-155),
+  # complementing the incomplete-data case above which drives the
+  # x_list branch.
+  data <- data.frame(
+    station_id = rep("M2", 10),
+    time = seq(as.POSIXct("2024-01-01"), by = "hour", length.out = 10),
+    wave_height = runif(10, 0.5, 5),
+    hmax = runif(10, 1, 15),
+    wind_speed = runif(10, 2, 25),
+    gust = runif(10, 5, 40),
+    atmospheric_pressure = runif(10, 990, 1030),
     qc_flag = rep(1L, 10),
     stringsAsFactors = FALSE
   )


### PR DESCRIPTION
## Problem

irishbuoys 0.2.0 is flagged **`check: ERROR`** on **every binary config** in `johngavin.r-universe.dev` (linux-devel/release, macOS oldrel/release, all three Windows) — only `source` and `wasm-release` are OK, so the package-level `_status` still reads `success` and the failure was easy to miss.

Root cause: `R/validation.R` reads `report$all_passed` from `pointblank::get_agent_report(display_table = FALSE)`, but **pointblank ≥ 0.12 removed the `all_passed` column** from that report tibble. So `!report$all_passed` raises `Error: invalid argument type` — but only on the branch reached when validation does **not** fully pass (incomplete data), which is why it stayed latent in normal pipeline use and only surfaced in the test suite (`test-validation.R:91`).

## Fix

Both sites now derive the per-step logical from the agent's x-list, which carries `all_passed`/`stop` on its `validation_set` data frame:

- `R/validation.R` (failure-summary branch): `x_list <- pointblank::get_agent_x_list(agent)`; `n_failed <- sum(!x_list$validation_set$all_passed, na.rm = TRUE)`; `any_stop <- any(x_list$validation_set$stop, na.rm = TRUE)` — dropping the now-unused `get_agent_report()` call.
- `R/validation.R` (`create_validation_summary()`): `checks_passed`/`checks_total` derived from `get_agent_x_list(agent)$validation_set` instead of `report`.

## Tests

`tests/testthat/test-validation.R` hardened: kept the incomplete-data case (drives the previously-buggy `all_passed == FALSE` branch, now covered by the x-list path) and added a complete-data case (drives the `all_passed == TRUE` early-return). Snapshot updated.

Verified in the project nix shell:
- validation filter: `FAIL 0 | WARN 2 | SKIP 0 | PASS 16` (was ERROR)
- full suite: `FAIL 0 | WARN 37 | SKIP 16 | PASS 1405`

The 37 warnings are pre-existing and unrelated (non-ASCII in `email_summary.R`/`storm_alert.R`, an undocumented `.Rd` arg, two vignettes without a recognised engine) — out of scope here.

This clears the binary-check ERROR across the r-universe build matrix.

*Diagnosed and fixed via delegated agents; finalized/verified by the orchestrator after two agent interruptions (API drop, then a background-test stall). Dispatch-Id in the commit footer.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
